### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,51 @@
 | **Cost** | Mac Mini 599$ | Most Linux SBC </br>~50$ |**Any Linux Board**</br>**As low as 10$** |
 <img src="assets/compare.jpg" alt="PicoClaw" width="512">
 
+---
 
+## 🏗 Architecture
+
+PicoClaw is designed around a lightweight, event-driven architecture:
+
+```mermaid
+flowchart TD
+
+    User -->|Message| Channels
+    Channels --> MessageBus
+    MessageBus --> AgentLoop
+    AgentLoop --> ToolRegistry
+    AgentLoop --> SkillSystem
+    ToolRegistry --> Tools
+    SkillSystem --> Skills
+    AgentLoop -->|Response| MessageBus
+    MessageBus --> Channels
+    Channels --> User
+
+    subgraph Channels
+        Telegram
+        Discord
+        QQ
+        DingTalk
+    end
+
+    subgraph Core
+        MessageBus["Message Bus"]
+        AgentLoop["Agent Loop"]
+        ToolRegistry["Tool Registry"]
+        SkillSystem["Skill System"]
+    end
+
+    subgraph Tools
+        WebSearch
+        Cron
+        FileSystem
+    end
+
+    subgraph Skills
+        CustomSkills
+    end
+
+```
 ## 🦾 Demonstration
 ### 🛠️ Standard Assistant Workflows
 <table align="center">


### PR DESCRIPTION
#1 
This PR adds a Mermaid architecture diagram to README.md that clearly illustrates the internal structure of PicoClaw, including the Message Bus, Channel system (Telegram, Discord, etc.), Agent Loop, Tool Registry, and Skill System.
The diagram visually explains how these components interact and improves overall project documentation and onboarding clarity.
Fixes #1

Type of Change
 Documentation update

Changes Made
Added a Mermaid architecture diagram to README.md
Illustrated relationships between core system components
Improved clarity of internal system flow
Ensured diagram renders correctly on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `README.md` with no impact on runtime behavior or security.
> 
> **Overview**
> Adds a new **Architecture** section to `README.md` with a Mermaid `flowchart` diagram showing the message flow between users, channel adapters (Telegram/Discord/QQ/DingTalk), and core components (Message Bus, Agent Loop, Tool Registry, Skill System), plus grouping of tools and skills for onboarding clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d78e48355d4e860fbd9b0d866d8e27e964c1b8fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->